### PR TITLE
Injectable middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,57 @@ Binds a method parameter to the koa context object.
 ### `@next()`
 Binds a method parameter to the next() function.
 
+## BaseMiddleware
+
+Extending `BaseMiddleware` allow us to inject dependencies 
+in Koa middleware function.
+
+```ts
+import { BaseMiddleware } from "inversify-koa-utils";
+
+@injectable()
+class LoggerMiddleware extends BaseMiddleware {
+    
+    @inject(TYPES.Logger) private readonly _logger: Logger;
+
+    public handler(ctx: Route.IRouteContext, next: () => Promise<any>): any {
+        this._logger.info(ctx);
+        await next();
+    }
+}
+```
+
+We also need to declare some type bindings:
+
+```ts
+const container = new Container();
+
+container.bind<Logger>(TYPES.Logger)
+        .to(Logger);
+
+container.bind<LoggerMiddleware>(TYPES.LoggerMiddleware)
+         .to(LoggerMiddleware);
+
+```
+
+We can then inject `TYPES.LoggerMiddleware` into one of our controllers. 
+
+```ts
+@injectable()
+@controller("/")
+class MyController extends BaseHttpController {
+
+    @httpGet("/", TYPES.LoggerMiddleware)
+    public async getResource() {
+        // controller logic
+    }
+}
+
+container.bind<interfaces.Controller>(TYPE.Controller)
+         .to(MyController)
+         .whenTargetNamed("MyController");
+```
+
 ## License
 
 License under the MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # inversify-koa-utils
 
-[![Join the chat at https://gitter.im/inversify/InversifyJS](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/inversify/InversifyJS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![inversify chat https://gitter.im/inversify/InversifyJS](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/inversify/InversifyJS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://secure.travis-ci.org/diego-d5000/inversify-koa-utils.svg?branch=master)](https://travis-ci.org/diego-d5000/inversify-koa-utils)
 [![Test Coverage](https://codeclimate.com/github/diego-d5000/inversify-koa-utils/badges/coverage.svg)](https://codeclimate.com/github/diego-d5000/inversify-koa-utils/coverage)
 [![npm version](https://badge.fury.io/js/inversify-koa-utils.svg)](http://badge.fury.io/js/inversify-koa-utils)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Binds a method parameter to the request headers.
 ### `@cookies()`
 Binds a method parameter to the request cookies.
 
+### `@context()`
+Binds a method parameter to the koa context object.
+
 ### `@next()`
 Binds a method parameter to the next() function.
 

--- a/src/base_middleware.ts
+++ b/src/base_middleware.ts
@@ -1,0 +1,11 @@
+import { injectable } from "inversify";
+import * as Router from "koa-router";
+import { interfaces } from "./interfaces";
+
+@injectable()
+export abstract class BaseMiddleware implements BaseMiddleware {
+    public abstract handler(
+        ctx: Router.IRouterContext,
+        next: () => Promise<any>
+    ): any;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 const TYPE = {
-    Controller: Symbol("Controller")
+    Controller: Symbol.for("Controller")
 };
 
 const METADATA_KEY = {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,6 @@
 import { interfaces } from "./interfaces";
-import { METADATA_KEY, PARAMETER_TYPE } from "./constants";
+import { inject } from "inversify";
+import { TYPE, METADATA_KEY, PARAMETER_TYPE } from "./constants";
 
 export function controller(path: string, ...middleware: interfaces.Middleware[]) {
     return function (target: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { InversifyKoaServer } from "./server";
 import { controller, httpMethod, httpGet, httpPut, httpPost, httpPatch,
         httpHead, all, httpDelete, request, response, requestParam, queryParam,
         requestBody, requestHeaders, cookies, next } from "./decorators";
+import { BaseMiddleware } from "./base_middleware";
 import { TYPE } from "./constants";
 import { interfaces } from "./interfaces";
 
@@ -25,5 +26,6 @@ export {
     requestBody,
     requestHeaders,
     cookies,
-    next
+    next,
+    BaseMiddleware
 };


### PR DESCRIPTION
Added an abstract class `BaseMiddleware` to create middleware classes which can be injected.

## Description
The implementation is the same as in inversify-express-utils

## Motivation and Context
This will be used to provide a central logger and auth handler as middleware.

## How Has This Been Tested?
Unit Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
