### PR TITLE
Added AuthProvider and authorization enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,57 @@ Binds a method parameter to the koa context object.
 ### `@next()`
 Binds a method parameter to the next() function.
 
+## BaseMiddleware
+
+Extending `BaseMiddleware` allow us to inject dependencies 
+in Koa middleware function.
+
+```ts
+import { BaseMiddleware } from "inversify-koa-utils";
+
+@injectable()
+class LoggerMiddleware extends BaseMiddleware {
+    
+    @inject(TYPES.Logger) private readonly _logger: Logger;
+
+    public handler(ctx: Route.IRouteContext, next: () => Promise<any>): any {
+        this._logger.info(ctx);
+        await next();
+    }
+}
+```
+
+We also need to declare some type bindings:
+
+```ts
+const container = new Container();
+
+container.bind<Logger>(TYPES.Logger)
+        .to(Logger);
+
+container.bind<LoggerMiddleware>(TYPES.LoggerMiddleware)
+         .to(LoggerMiddleware);
+
+```
+
+We can then inject `TYPES.LoggerMiddleware` into one of our controllers. 
+
+```ts
+@injectable()
+@controller("/")
+class MyController extends BaseHttpController {
+
+    @httpGet("/", TYPES.LoggerMiddleware)
+    public async getResource() {
+        // controller logic
+    }
+}
+
+container.bind<interfaces.Controller>(TYPE.Controller)
+         .to(MyController)
+         .whenTargetNamed("MyController");
+```
+
 ## License
 
 License under the MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # inversify-koa-utils
 
-[![Join the chat at https://gitter.im/inversify/InversifyJS](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/inversify/InversifyJS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![inversify chat https://gitter.im/inversify/InversifyJS](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/inversify/InversifyJS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://secure.travis-ci.org/diego-d5000/inversify-koa-utils.svg?branch=master)](https://travis-ci.org/diego-d5000/inversify-koa-utils)
 [![Test Coverage](https://codeclimate.com/github/diego-d5000/inversify-koa-utils/badges/coverage.svg)](https://codeclimate.com/github/diego-d5000/inversify-koa-utils/coverage)
 [![npm version](https://badge.fury.io/js/inversify-koa-utils.svg)](http://badge.fury.io/js/inversify-koa-utils)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ Binds a method parameter to the request headers.
 ### `@cookies()`
 Binds a method parameter to the request cookies.
 
+### `@context()`
+Binds a method parameter to the koa context object.
+
 ### `@next()`
 Binds a method parameter to the next() function.
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ Binds a method parameter to the koa context object.
 ### `@next()`
 Binds a method parameter to the next() function.
 
+### `@authorize([role: string, ...])`
+Ensures that only authenticated and authorized users can invoke this controller method. If authentication fails the status code 401 will be returned. If authorization fails the status code 403 will be returned. Even if authentication or authorization fail all middlewares (for router, controller and method) will be invoked. If you don't provide any roles only authentication will be ensured.
+
+### `@authorizeAll([role: string, ...])`
+Ensures that only authenticated and authorized users can invoke the entire controller. Behaviour is the same as in `@authorize`.
+
 ## AuthProvider
 
 You can provide a custom `AuthProvider` to create and provida a principal for the current request.
@@ -315,11 +321,28 @@ class UserDetailsController extends BaseHttpController {
 
     @httpGet("/")
     public async getUserDetails(@context() ctx: Router.IRouterContext) {
-        if (this.context.principal.isAuthenticated()) {
+        if (await this.context.principal.isAuthenticated()) {
             return this._authService.getUserDetails(this.context.principal.details.id);
         } else {
             throw new Error();
         }
+    }
+}
+```
+
+If you want to ensure that only authenticatied users can invoke a method you can use `@authorize`:
+
+```ts
+@controller("/")
+class UserDetailsController extends BaseHttpController {
+
+    @inject("AuthService") private readonly _authService: AuthService;
+
+    @httpGet("/")
+    @authorize()
+    public async getUserDetails(@context() ctx: Router.IRouterContext) {
+        let isAuthorized = await this.context.principal.isAuthenticated();
+        // isAuthorized will always be true
     }
 }
 ```

--- a/src/base_middleware.ts
+++ b/src/base_middleware.ts
@@ -1,0 +1,11 @@
+import { injectable } from "inversify";
+import * as Router from "koa-router";
+import { interfaces } from "./interfaces";
+
+@injectable()
+export abstract class BaseMiddleware implements BaseMiddleware {
+    public abstract handler(
+        ctx: Router.IRouterContext,
+        next: () => Promise<any>
+    ): any;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 const TYPE = {
-    Controller: Symbol("Controller")
+    Controller: Symbol.for("Controller")
 };
 
 const METADATA_KEY = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 const TYPE = {
+    AuthProvider: Symbol.for("AuthProvider"),
     Controller: Symbol.for("Controller")
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,8 @@ const TYPE = {
 };
 
 const METADATA_KEY = {
+    authorize: "_authorize",
+    authorizeAll: "_authorize-all",
     controller: "_controller",
     controllerMethod: "_controller-method",
     controllerParameter: "_controller-parameter"

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,6 @@
 import { interfaces } from "./interfaces";
-import { METADATA_KEY, PARAMETER_TYPE } from "./constants";
+import { inject } from "inversify";
+import { TYPE, METADATA_KEY, PARAMETER_TYPE } from "./constants";
 
 export function controller(path: string, ...middleware: interfaces.Middleware[]) {
     return function (target: any) {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -52,6 +52,28 @@ export function httpMethod(method: string, path: string, ...middleware: interfac
     };
 }
 
+export function authorizeAll(...requiredRoles: string[]) {
+    return function (target: any) {
+        let metadata: interfaces.AuthorizeAllMetadata = {requiredRoles, target};
+        Reflect.defineMetadata(METADATA_KEY.authorizeAll, metadata, target);
+    };
+}
+
+export function authorize(...requiredRoles: string[]): interfaces.HandlerDecorator {
+    return function (target: any, key: string, value: any) {
+        let metadata: interfaces.AuthorizeMetadata = {requiredRoles, target, key};
+        let metadataList: interfaces.AuthorizeMetadata[] = [];
+
+        if (!Reflect.hasOwnMetadata(METADATA_KEY.authorize, target.constructor)) {
+            Reflect.defineMetadata(METADATA_KEY.authorize, metadataList, target.constructor);
+        } else {
+            metadataList = Reflect.getOwnMetadata(METADATA_KEY.authorize, target.constructor);
+        }
+
+        metadataList[key] = metadata;
+    };
+}
+
 export const request = paramDecoratorFactory(PARAMETER_TYPE.REQUEST);
 export const response = paramDecoratorFactory(PARAMETER_TYPE.RESPONSE);
 export const requestParam = paramDecoratorFactory(PARAMETER_TYPE.PARAMS);

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -40,13 +40,7 @@ export function httpDelete(path: string, ...middleware: interfaces.Middleware[])
 export function httpMethod(method: string, path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return function (target: any, key: string, value: any) {
         let metadata: interfaces.ControllerMethodMetadata = {path, middleware, method, target, key};
-        let metadataList: interfaces.ControllerMethodMetadata[] = [];
-
-        if (!Reflect.hasOwnMetadata(METADATA_KEY.controllerMethod, target.constructor)) {
-            Reflect.defineMetadata(METADATA_KEY.controllerMethod, metadataList, target.constructor);
-        } else {
-            metadataList = Reflect.getOwnMetadata(METADATA_KEY.controllerMethod, target.constructor);
-        }
+        let metadataList: interfaces.ControllerMethodMetadata[] = getMetadataList(METADATA_KEY.controllerMethod, target);
 
         metadataList.push(metadata);
     };
@@ -62,16 +56,22 @@ export function authorizeAll(...requiredRoles: string[]) {
 export function authorize(...requiredRoles: string[]): interfaces.HandlerDecorator {
     return function (target: any, key: string, value: any) {
         let metadata: interfaces.AuthorizeMetadata = {requiredRoles, target, key};
-        let metadataList: interfaces.AuthorizeMetadata[] = [];
-
-        if (!Reflect.hasOwnMetadata(METADATA_KEY.authorize, target.constructor)) {
-            Reflect.defineMetadata(METADATA_KEY.authorize, metadataList, target.constructor);
-        } else {
-            metadataList = Reflect.getOwnMetadata(METADATA_KEY.authorize, target.constructor);
-        }
+        let metadataList: interfaces.AuthorizeMetadata[] = getMetadataList(METADATA_KEY.authorize, target);
 
         metadataList[key] = metadata;
     };
+}
+
+function getMetadataList<T>(metadataKey: string, target: any): T[] {
+    let metadataList: T[] = [];
+
+    if (!Reflect.hasOwnMetadata(metadataKey, target.constructor)) {
+        Reflect.defineMetadata(metadataKey, metadataList, target.constructor);
+    } else {
+        metadataList = Reflect.getOwnMetadata(metadataKey, target.constructor);
+    }
+
+    return metadataList;
 }
 
 export const request = paramDecoratorFactory(PARAMETER_TYPE.REQUEST);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { InversifyKoaServer } from "./server";
 import { controller, httpMethod, httpGet, httpPut, httpPost, httpPatch,
         httpHead, all, httpDelete, request, response, requestParam, queryParam,
         requestBody, requestHeaders, cookies, next } from "./decorators";
+import { BaseMiddleware } from "./base_middleware";
 import { TYPE } from "./constants";
 import { interfaces } from "./interfaces";
 
@@ -25,5 +26,6 @@ export {
     requestBody,
     requestHeaders,
     cookies,
-    next
+    next,
+    BaseMiddleware
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -46,6 +46,19 @@ namespace interfaces {
         (ctx: Router.IRouterContext, next: () => Promise<any>): any;
     }
 
+    export interface Principal {
+        details: any;
+        isAuthenticated(): Promise<boolean>;
+        // Allows content-based auth
+        isResourceOwner(resourceId: any): Promise<boolean>;
+        // Allows role-based auth
+        isInRole(role: string): Promise<boolean>;
+    }
+
+    export interface AuthProvider {
+        getPrincipal(ctx: Router.IRouterContext): Promise<Principal>;
+    }
+
 }
 
 export { interfaces };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,6 +28,15 @@ namespace interfaces {
         type: PARAMETER_TYPE;
     }
 
+    export interface AuthorizeAllMetadata {
+        requiredRoles: string[];
+        target: any;
+    }
+
+    export interface AuthorizeMetadata extends AuthorizeAllMetadata {
+        key: string;
+    }
+
     export interface Controller {}
 
     export interface HandlerDecorator {

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -13,7 +13,7 @@ import {
     controller, httpMethod, all, httpGet, httpPost, httpPut, httpPatch,
     httpHead, httpDelete, request, response, params, requestParam,
     requestBody, queryParam, requestHeaders, cookies,
-    next, context
+    next, context, authorize, authorizeAll
 } from "../src/decorators";
 import { TYPE, PARAMETER_TYPE } from "../src/constants";
 import { BaseMiddleware } from "../src/base_middleware";
@@ -94,7 +94,6 @@ describe("Integration Tests:", () => {
                 .expect(200, "GET", done);
         });
 
-
         it("should work for async methods which call nextFunc()", (done) => {
             @injectable()
             @controller("/")
@@ -120,7 +119,6 @@ describe("Integration Tests:", () => {
                 .expect(200, "GET", done);
         });
 
-
         it("should work for async methods called by nextFunc()", (done) => {
             @injectable()
             @controller("/")
@@ -142,7 +140,6 @@ describe("Integration Tests:", () => {
                 .get("/")
                 .expect(200, "GET", done);
         });
-
 
         it("should work for each shortcut decorator", (done) => {
             @injectable()
@@ -170,7 +167,6 @@ describe("Integration Tests:", () => {
             get();
         });
 
-
         it("should work for more obscure HTTP methods using the httpMethod decorator", (done) => {
             @injectable()
             @controller("/")
@@ -184,7 +180,6 @@ describe("Integration Tests:", () => {
                 .propfind("/")
                 .expect(200, "PROPFIND", done);
         });
-
 
         it("should use returned values as response", (done) => {
             let result = { "hello": "world" };
@@ -462,7 +457,6 @@ describe("Integration Tests:", () => {
                 });
         });
 
-
         it("should call controller-level middleware correctly", (done) => {
             @injectable()
             @controller("/", spyA, spyB, spyC)
@@ -482,7 +476,6 @@ describe("Integration Tests:", () => {
                     done();
                 });
         });
-
 
         it("should call injected controller-level BaseMiddleware correctly", (done) => {
 
@@ -523,7 +516,6 @@ describe("Integration Tests:", () => {
                 });
         });
 
-
         it("should call server-level middleware correctly", (done) => {
             @injectable()
             @controller("/")
@@ -550,7 +542,6 @@ describe("Integration Tests:", () => {
                     done();
                 });
         });
-
 
         it("should call all middleware in correct order", (done) => {
             @injectable()
@@ -660,6 +651,8 @@ describe("Integration Tests:", () => {
                 });
         });
     });
+
+
     describe("Parameters:", () => {
         it("should bind a method parameter to the url parameter of the web request", (done) => {
             @injectable()
@@ -824,6 +817,299 @@ describe("Integration Tests:", () => {
             server = new InversifyKoaServer(container);
             supertest(server.build().listen())
                 .get("/")
+                .expect(200, "foo", done);
+        });
+    });
+
+
+    describe("Authorization:", () => {
+        it("should respond with 401 if there is no auth provider and controller is decorated with @authorizeAll", (done) => {
+            @injectable()
+            @controller("/")
+            @authorizeAll()
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(401, done);
+        });
+
+        it("should respond with 401 if provided principal is not authenticated and controller is decorated with @authorizeAll", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(false),
+                        isInRole: (role: string) => Promise.resolve(true),
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            @authorizeAll()
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(401, done);
+        });
+
+        it("should respond with 403 if provided principal is not in role and controller is decorated with @authorizeAll", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(true),
+                        isInRole: (role: string) => {
+                            if (role === "role a") {
+                                return Promise.resolve(true);
+                            }
+                            return Promise.resolve(false);
+                        },
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            @authorizeAll("role a", "role b")
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(403, done);
+        });
+
+        it("should invoke controller if provided principal is authorized according to roles in @authorizeAll", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(true),
+                        isInRole: (role: string) => Promise.resolve(true),
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            @authorizeAll("role a", "role b")
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(200, "foo", done);
+        });
+
+        it("should invoke controller if provided principal is authenticated and no roles are enforced in @authorizeAll", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(true),
+                        isInRole: (role: string) => Promise.resolve(false),
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            @authorizeAll()
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(200, "foo", done);
+        });
+
+        // =====
+        it("should respond with 401 if there is no auth provider and method is decorated with @authorize", (done) => {
+            @injectable()
+            @controller("/")
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") @authorize() public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(401, done);
+        });
+
+        it("should respond with 401 if provided principal is not authenticated and method is decorated with @authorize", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(false),
+                        isInRole: (role: string) => Promise.resolve(true),
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") @authorize() public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(401, done);
+        });
+
+        it("should respond with 403 if provided principal is not in role and method is decorated with @authorize", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(true),
+                        isInRole: (role: string) => {
+                            if (role === "role a") {
+                                return Promise.resolve(true);
+                            }
+                            return Promise.resolve(false);
+                        },
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") @authorize("role a", "role b") public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(403, done);
+        });
+
+        it("should invoke controller if provided principal is authorized according to roles in @authorize", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(true),
+                        isInRole: (role: string) => Promise.resolve(true),
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") @authorize("role a", "role b") public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
+                .expect(200, "foo", done);
+        });
+
+        it("should invoke controller if provided principal is authenticated and no roles are enforced in @authorize", (done) => {
+            @injectable()
+            class TestAuthProvider implements interfaces.AuthProvider {
+                public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                    let principal: interfaces.Principal = {
+                        details: null,
+                        isAuthenticated: () => Promise.resolve(true),
+                        isInRole: (role: string) => Promise.resolve(false),
+                        isResourceOwner: (resourceId: any) => Promise.resolve(true)
+                    };
+                    return Promise.resolve(principal);
+                }
+            }
+
+            @injectable()
+            @controller("/")
+            class TestController {
+                // tslint:disable-next-line:max-line-length
+                @httpGet(":id") @authorize() public getTest( @requestParam("id") id: string, ctx: Router.IRouterContext) {
+                    return id;
+                }
+            }
+            container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyKoaServer(container, null, null, null, TestAuthProvider);
+            supertest(server.build().listen())
+                .get("/foo")
                 .expect(200, "foo", done);
         });
     });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -8,6 +8,7 @@ import * as Router from "koa-router";
 import { InversifyKoaServer } from "../src/server";
 import { Container, injectable } from "inversify";
 import { TYPE } from "../src/constants";
+import { interfaces } from "../src/interfaces";
 
 describe("Unit Test: InversifyKoaServer", () => {
 
@@ -81,5 +82,18 @@ describe("Unit Test: InversifyKoaServer", () => {
         expect((serverWithCustomApp as any)._app).to.eq(app);
         // deeply equal causes error with property URL
         expect((serverWithDefaultApp as any)._app).to.not.equal((serverWithCustomApp as any)._app);
+    });
+
+    it("Should allow to provide a auth provider", () => {
+        class MyAuthProvider implements interfaces.AuthProvider {
+            public getPrincipal(ctx: Router.IRouterContext): Promise<interfaces.Principal> {
+                return Promise.resolve(null);
+            }
+        }
+        let container = new Container();
+
+        let server = new InversifyKoaServer(container, null, null, null, MyAuthProvider);
+
+        expect((server as any)._AuthProvider).to.eq(MyAuthProvider);
     });
 });


### PR DESCRIPTION
The user can now use `@authorize` and `@authorizeAll` on controller and controller method to enforce that the client is authenticated and authorized.

## Description
To enforce authentication and authorization an implementation of AuthProvider must be provided. This provider should provide a principal which represents roles (like in inversify-express-utils).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Central authentication and authorization middleware.

## How Has This Been Tested?
Unit and integration tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
