### PR TITLE
Hotfix export context

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Binds a method parameter to request.body or to a specific body property if a nam
 ### `@requestHeaders(name?: string)`
 Binds a method parameter to the request headers.
 
+### `@context()`
+Binds a method parameter to the koa context object.
+
 ### `@cookies()`
 Binds a method parameter to the request cookies.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { InversifyKoaServer } from "./server";
 import { controller, httpMethod, httpGet, httpPut, httpPost, httpPatch,
         httpHead, all, httpDelete, request, response, requestParam, queryParam,
-        requestBody, requestHeaders, cookies, next } from "./decorators";
+        requestBody, requestHeaders, cookies, next, context } from "./decorators";
 import { TYPE } from "./constants";
 import { interfaces } from "./interfaces";
 
@@ -25,5 +25,6 @@ export {
     requestBody,
     requestHeaders,
     cookies,
-    next
+    next,
+    context
 };


### PR DESCRIPTION
Context is not exported but it is necessary to move data between middlewares (the right way).